### PR TITLE
Automatically import known SOAP related schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .php-cs-fixer.cache
 /*.wsdl
 composer.lock
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="tests/bootstrap.php" executionOrder="random" beStrictAboutOutputDuringTests="false" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false" beStrictAboutCoverageMetadata="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="tests/bootstrap.php" executionOrder="random" beStrictAboutOutputDuringTests="false" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false" beStrictAboutCoverageMetadata="false">
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">tests/Unit</directory>
@@ -11,9 +11,10 @@
       <directory suffix="Test.php">tests/Integration</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <coverage/>
+  <source>
     <include>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/tests/PhpCompatibility/schema004.phpt
+++ b/tests/PhpCompatibility/schema004.phpt
@@ -13,4 +13,4 @@ EOF;
 test_schema($schema,'type="tns:testType"');
 ?>
 --EXPECT--
-FATAL (GoetasWebservices\XML\XSDReader\Exception\TypeException):Can't find type named {http://test-uri/}#testType2, at line 17 in some.wsdl
+FATAL (GoetasWebservices\XML\XSDReader\Exception\TypeException):Can't find type named {http://test-uri/}#testType2, at line 13 in some.wsdl

--- a/tests/PhpCompatibility/test_schema.inc
+++ b/tests/PhpCompatibility/test_schema.inc
@@ -5,7 +5,6 @@ use Soap\Engine\Metadata\Model\Type;
 use Soap\Wsdl\Loader\CallbackLoader;
 use Soap\WsdlReader\Formatter\LongTypeFormatter;
 use Soap\WsdlReader\Formatter\ShortMethodFormatter;
-use Soap\WsdlReader\Formatter\ShortTypeFormatter;
 use Soap\WsdlReader\Metadata\Wsdl1MetadataProvider;
 use Soap\WsdlReader\Wsdl1Reader;
 
@@ -25,10 +24,6 @@ function test_schema($schema, $type, $style="rpc",$use="encoded", $attributeForm
       >
     <types>
     <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://test-uri/" $attributeFormDefault>
-     <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/" /><!-- SOAP 1.1-->
-     <xsd:import namespace="http://www.w3.org/2003/05/soap-encoding" /><!-- SOAP 1.2 - 2003-05 -->
-     <xsd:import namespace="http://xml.apache.org/xml-soap" />
-     <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/" />
       $schema
     </schema>
     </types>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #7

#### Summary

Fixes #7
The known namespaces will now be auto-imported into the globally shared XSD schema.
This way, we don't require the WSDL to specifically import any SOAP related schema's manually.
