### PR TITLE
Improve bottom type inference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^8.1",
         "ext-dom": "*",
         "goetas-webservices/xsd-reader": "^0.4.1",
-        "php-soap/engine": "^2.3",
+        "php-soap/engine": "^2.4",
         "php-soap/wsdl": "^1.4",
         "veewee/xml": "^2.6",
         "azjezz/psl": "^2.4",
@@ -25,7 +25,7 @@
     "require-dev": {
         "veewee/composer-run-parallel": "^1.2",
         "symfony/var-dumper": "^6.1",
-        "php-soap/engine-integration-tests": "^1.4.2",
+        "php-soap/engine-integration-tests": "^1.5.0",
         "psalm/plugin-symfony": "^5.0",
         "php-standard-library/psalm-plugin": "^2.2",
         "vimeo/psalm": "^5.6"

--- a/src/Formatter/LongTypeFormatter.php
+++ b/src/Formatter/LongTypeFormatter.php
@@ -13,9 +13,14 @@ final class LongTypeFormatter
     public function __invoke(Type $type): string
     {
         $hasProps = (bool) $type->getProperties()->count();
+        $meta = $type->getXsdType()->getMeta();
+        $extension = $meta->extends()->map(
+            static fn ($extends): string => $extends['type']
+        )->unwrapOr(null);
+
         $declaration = [
             $type->getXsdType()->getXmlNamespace() . ':'.$type->getName(),
-            $type->getXsdType()->getBaseType() ? ' extends '.$type->getXsdType()->getBaseType() : '',
+            $extension ? ' extends '.$extension : '',
             (new EnumFormatter())($type->getXsdType()),
             (new UnionFormatter())($type->getXsdType()),
             $hasProps ? ' {' : '',

--- a/src/Metadata/Converter/Types/Configurator/AttributeBaseTypeConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/AttributeBaseTypeConfigurator.php
@@ -7,7 +7,6 @@ use GoetasWebservices\XML\XSDReader\Schema\Attribute\AbstractAttributeItem;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeItem;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeRef;
 use Soap\Engine\Metadata\Model\XsdType as EngineType;
-use Soap\WsdlReader\Metadata\Converter\Types\Mapper\BaseTypeMapper;
 use Soap\WsdlReader\Metadata\Converter\Types\TypesConverterContext;
 
 final class AttributeBaseTypeConfigurator
@@ -24,6 +23,6 @@ final class AttributeBaseTypeConfigurator
             default => null,
         };
 
-        return (new BaseTypeMapper())($engineType, $baseType, $context);
+        return (new SimpleTypeConfigurator())($engineType, $baseType, $context);
     }
 }

--- a/src/Metadata/Converter/Types/Configurator/ExtendsConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/ExtendsConfigurator.php
@@ -24,21 +24,14 @@ final class ExtendsConfigurator
             return $engineType;
         }
 
-        $engineType = $engineType
+        return $engineType
             ->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withExtends([
                     'type' => $name,
                     'namespace' => $base?->getSchema()->getTargetNamespace() ?? '',
                     'isSimple' => $base instanceof SimpleType,
                 ])
-            );
-
-        // Only set the base-type of the engine-type if current type is not part of the base-types.
-        // (e.g.: string, integer, ...)
-        if (!$context->isBaseSchema($xsdType->getSchema())) {
-            $engineType = $engineType->withBaseType($name);
-        }
-
-        return $engineType;
+            )
+            ->withBaseType($name);
     }
 }

--- a/src/Metadata/Converter/Types/Configurator/SimpleTypeConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/SimpleTypeConfigurator.php
@@ -19,8 +19,7 @@ final class SimpleTypeConfigurator
 
         $configure = pipe(
             static fn (EngineType $engineType): EngineType => (new RestrictionsConfigurator())($engineType, $xsdType->getRestriction(), $context),
-            static fn (EngineType $engineType): EngineType => (new SimpleListConfigurator())($engineType, $xsdType, $context),
-            static fn (EngineType $engineType): EngineType => (new SimpleUnionsConfigurator())($engineType, $xsdType, $context),
+            static fn (EngineType $engineType): EngineType => (new SimpleBottomTypeConfigurator())($engineType, $xsdType, $context),
         );
 
         return $configure(

--- a/src/Metadata/Converter/Types/Configurator/SimpleUnionsConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/SimpleUnionsConfigurator.php
@@ -24,6 +24,7 @@ final class SimpleUnionsConfigurator
         $mapUnions = new UnionTypesMapper();
 
         return $metaType
+            ->withBaseType('mixed')
             ->withMemberTypes(
                 $mapUnions(
                     $unions,

--- a/src/Metadata/Converter/Types/Mapper/UnionTypesMapper.php
+++ b/src/Metadata/Converter/Types/Mapper/UnionTypesMapper.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 namespace Soap\WsdlReader\Metadata\Converter\Types\Mapper;
 
 use GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType;
-use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
-use Soap\Engine\Metadata\Model\XsdType as EngineType;
-use Soap\WsdlReader\Metadata\Converter\Types\Configurator\SimpleListConfigurator;
-use Soap\WsdlReader\Metadata\Converter\Types\Configurator\SimpleUnionsConfigurator;
-use Soap\WsdlReader\Metadata\Converter\Types\TypesConverterContext;
 use function Psl\Vec\filter_nulls;
 use function Psl\Vec\map;
 

--- a/src/Metadata/Converter/Types/Mapper/UnionTypesMapper.php
+++ b/src/Metadata/Converter/Types/Mapper/UnionTypesMapper.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 namespace Soap\WsdlReader\Metadata\Converter\Types\Mapper;
 
 use GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType;
+use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
+use Soap\Engine\Metadata\Model\XsdType as EngineType;
+use Soap\WsdlReader\Metadata\Converter\Types\Configurator\SimpleListConfigurator;
+use Soap\WsdlReader\Metadata\Converter\Types\Configurator\SimpleUnionsConfigurator;
+use Soap\WsdlReader\Metadata\Converter\Types\TypesConverterContext;
 use function Psl\Vec\filter_nulls;
 use function Psl\Vec\map;
 

--- a/src/Metadata/Converter/Types/Visitor/InlineElementTypeVisitor.php
+++ b/src/Metadata/Converter/Types/Visitor/InlineElementTypeVisitor.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace Soap\WsdlReader\Metadata\Converter\Types\Visitor;
 
 use GoetasWebservices\XML\XSDReader\Schema\Element\AbstractElementSingle;
+use GoetasWebservices\XML\XSDReader\Schema\Element\ElementContainer;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementItem;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementRef;
+use GoetasWebservices\XML\XSDReader\Schema\Type\BaseComplexType;
 use GoetasWebservices\XML\XSDReader\Schema\Type\ComplexType;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 use Soap\Engine\Metadata\Collection\TypeCollection;
@@ -24,29 +26,42 @@ final class InlineElementTypeVisitor
             return new TypeCollection();
         }
 
-        $elementVisitor = new ElementVisitor();
-
         return new TypeCollection(
             ...flat_map(
                 $xsdType->getElements(),
-                static function (ElementItem $element) use ($elementVisitor, $context): TypeCollection {
-                    if (!$element instanceof AbstractElementSingle || $element instanceof ElementRef) {
-                        return new TypeCollection();
-                    }
-
-                    // There is no need to create types for simple elements like strings.
-                    if (!$element->getType() instanceof ComplexType || !$element->isLocal()) {
-                        return new TypeCollection();
-                    }
-
-                    // If the element links to a named type, we already know about it.
-                    if ($element->getType()?->getName()) {
-                        return new TypeCollection();
-                    }
-
-                    return $elementVisitor($element, $context);
-                }
+                fn (ElementItem $element): TypeCollection => $this->detectInlineTypes($element, $context)
             )
         );
+    }
+
+    private function detectInlineTypes(ElementItem $element, TypesConverterContext $context): TypeCollection
+    {
+        $elementVisitor = new ElementVisitor();
+
+        // Handle nested element containers (like "choice" with inline elements)
+        if ($element instanceof ElementContainer) {
+            return new TypeCollection(
+                ...flat_map(
+                    $element->getElements(),
+                    fn (ElementItem $child): TypeCollection => $this->detectInlineTypes($child, $context)
+                )
+            );
+        }
+
+        if (!$element instanceof AbstractElementSingle || $element instanceof ElementRef) {
+            return new TypeCollection();
+        }
+
+        // There is no need to create types for simple elements like strings.
+        if (!$element->getType() instanceof BaseComplexType || !$element->isLocal()) {
+            return new TypeCollection();
+        }
+
+        // If the element links to a named type, we already know about it.
+        if ($element->getType()?->getName()) {
+            return new TypeCollection();
+        }
+
+        return $elementVisitor($element, $context);
     }
 }

--- a/tests/PhpCompatibility/schema001.phpt
+++ b/tests/PhpCompatibility/schema001.phpt
@@ -15,4 +15,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends integer
+  > http://test-uri/:testType extends int

--- a/tests/PhpCompatibility/schema002.phpt
+++ b/tests/PhpCompatibility/schema002.phpt
@@ -18,5 +18,5 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int
   > http://test-uri/:testType extends testType2

--- a/tests/PhpCompatibility/schema003.phpt
+++ b/tests/PhpCompatibility/schema003.phpt
@@ -19,4 +19,4 @@ Methods:
 
 Types:
   > http://test-uri/:testType extends testType2
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int

--- a/tests/PhpCompatibility/schema005.phpt
+++ b/tests/PhpCompatibility/schema005.phpt
@@ -20,4 +20,4 @@ Methods:
 
 Types:
   > http://test-uri/:testType extends testType2
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int

--- a/tests/PhpCompatibility/schema006.phpt
+++ b/tests/PhpCompatibility/schema006.phpt
@@ -21,5 +21,5 @@ Methods:
 
 Types:
   > http://test-uri/:testType extends testType2
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int
   > http://test-uri/:testElement extends testType2

--- a/tests/PhpCompatibility/schema007.phpt
+++ b/tests/PhpCompatibility/schema007.phpt
@@ -21,5 +21,5 @@ Methods:
 
 Types:
   > http://test-uri/:testType extends testType2
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int
   > http://test-uri/:testElement extends testType2

--- a/tests/PhpCompatibility/schema008.phpt
+++ b/tests/PhpCompatibility/schema008.phpt
@@ -21,5 +21,5 @@ Methods:
   > test(testElement $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer
+  > http://test-uri/:testType2 extends int
   > http://test-uri/:testElement extends testType2

--- a/tests/PhpCompatibility/schema009.phpt
+++ b/tests/PhpCompatibility/schema009.phpt
@@ -15,4 +15,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<token>)
+  > http://test-uri/:testType = (list<token>)

--- a/tests/PhpCompatibility/schema010.phpt
+++ b/tests/PhpCompatibility/schema010.phpt
@@ -15,4 +15,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<token>)
+  > http://test-uri/:testType = (list<token>)

--- a/tests/PhpCompatibility/schema011.phpt
+++ b/tests/PhpCompatibility/schema011.phpt
@@ -19,4 +19,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<int>)
+  > http://test-uri/:testType = (list<int>)

--- a/tests/PhpCompatibility/schema012.phpt
+++ b/tests/PhpCompatibility/schema012.phpt
@@ -19,4 +19,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<int>)
+  > http://test-uri/:testType = (list<int>)

--- a/tests/PhpCompatibility/schema021.phpt
+++ b/tests/PhpCompatibility/schema021.phpt
@@ -19,4 +19,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<int|float|string>)
+  > http://test-uri/:testType = (list<int|float|string>)

--- a/tests/PhpCompatibility/schema022.phpt
+++ b/tests/PhpCompatibility/schema022.phpt
@@ -21,4 +21,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array = (list<int|float|string>)
+  > http://test-uri/:testType = (list<int|float|string>)

--- a/tests/PhpCompatibility/schema042.phpt
+++ b/tests/PhpCompatibility/schema042.phpt
@@ -19,7 +19,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends integer {
+  > http://test-uri/:testType extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema043.phpt
+++ b/tests/PhpCompatibility/schema043.phpt
@@ -26,7 +26,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer {
+  > http://test-uri/:testType2 extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema044.phpt
+++ b/tests/PhpCompatibility/schema044.phpt
@@ -19,7 +19,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends integer {
+  > http://test-uri/:testType extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema045.phpt
+++ b/tests/PhpCompatibility/schema045.phpt
@@ -26,7 +26,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer {
+  > http://test-uri/:testType2 extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema046.phpt
+++ b/tests/PhpCompatibility/schema046.phpt
@@ -26,7 +26,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer {
+  > http://test-uri/:testType2 extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema048.phpt
+++ b/tests/PhpCompatibility/schema048.phpt
@@ -26,7 +26,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType2 extends integer {
+  > http://test-uri/:testType2 extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema055.phpt
+++ b/tests/PhpCompatibility/schema055.phpt
@@ -20,4 +20,4 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends array
+  > http://test-uri/:testType extends Map

--- a/tests/PhpCompatibility/schema062.phpt
+++ b/tests/PhpCompatibility/schema062.phpt
@@ -19,7 +19,7 @@ Methods:
   > test(testType $testParam): void
 
 Types:
-  > http://test-uri/:testType extends integer {
+  > http://test-uri/:testType extends int {
     int $_
     @int $int
   }

--- a/tests/PhpCompatibility/schema1001.phpt
+++ b/tests/PhpCompatibility/schema1001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-SOAP XML Schema 18: union with list
+SOAP XML Schema 1001: Enums
 --FILE--
 <?php
 include __DIR__."/test_schema.inc";

--- a/tests/PhpCompatibility/schema1002.phpt
+++ b/tests/PhpCompatibility/schema1002.phpt
@@ -1,37 +1,19 @@
 --TEST--
-SOAP XML Schema 18: union with list
+SOAP XML Schema 1002: nested complex types
 --FILE--
 <?php
 include __DIR__."/test_schema.inc";
 $schema = <<<EOF
     <complexType name="VoluntaryChangesType">
-		<annotation>
-			<documentation xml:lang="en">Specifies charges and/or penalties associated with making ticket changes after purchase.</documentation>
-		</annotation>
 		<sequence minOccurs="0">
 			<element name="Penalty" minOccurs="0">
-				<annotation>
-					<documentation xml:lang="en">Specifies penalty charges as either a currency amount or a percentage of the fare</documentation>
-				</annotation>
 				<complexType>
-					<attribute name="PenaltyType" type="string" use="optional">
-						<annotation>
-							<documentation xml:lang="en">Indicates the type of penalty involved in the search or response.</documentation>
-						</annotation>
-					</attribute>
-					<attribute name="DepartureStatus" type="string" use="optional">
-						<annotation>
-							<documentation xml:lang="en">Identifier used to indicate whether the change occurs before or after departure from the origin city.</documentation>
-						</annotation>
-					</attribute>
+					<attribute name="PenaltyType" type="string" use="optional"/>
+					<attribute name="DepartureStatus" type="string" use="optional"/>
 				</complexType>
 			</element>
 		</sequence>
-		<attribute name="VolChangeInd" type="boolean" use="optional">
-			<annotation>
-				<documentation xml:lang="en">Indicator used to specify whether voluntary change and other penalties are involved in the search or response.</documentation>
-			</annotation>
-		</attribute>
+		<attribute name="VolChangeInd" type="boolean" use="optional"/>
 	</complexType>
 EOF;
 test_schema($schema,'type="tns:VoluntaryChangesType"');

--- a/tests/PhpCompatibility/schema1003.phpt
+++ b/tests/PhpCompatibility/schema1003.phpt
@@ -29,6 +29,6 @@ Types:
   > http://test-uri/:SpecialEquipPrefs {
     array<int<1, 15>, SpecialEquipPref> $SpecialEquipPref
   }
-  > http://test-uri/:SpecialEquipPref extends array {
+  > http://test-uri/:SpecialEquipPref {
     @string $Action
   }

--- a/tests/PhpCompatibility/schema1003.phpt
+++ b/tests/PhpCompatibility/schema1003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-SOAP XML Schema 18: union with list
+SOAP XML Schema 1002: nested elements within complex types
 --FILE--
 <?php
 include __DIR__."/test_schema.inc";

--- a/tests/PhpCompatibility/schema1004.phpt
+++ b/tests/PhpCompatibility/schema1004.phpt
@@ -1,0 +1,41 @@
+--TEST--
+SOAP XML Schema 1004: Nested simple types
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+	<simpleType name="StringLength1to128">
+		<restriction base="string">
+			<minLength value="1"/>
+			<maxLength value="128"/>
+		</restriction>
+	</simpleType>
+	<complexType name="EmailType">
+        <simpleContent>
+            <extension base="tns:StringLength1to128">
+                <attribute name="EmailType" type="string" use="optional" />
+            </extension>
+        </simpleContent>
+    </complexType>
+    <complexType name="VerificationType">
+		<sequence>
+			<element name="Email" type="tns:EmailType" minOccurs="0">
+			</element>
+		</sequence>
+	</complexType>
+EOF;
+test_schema($schema,'type="tns:SpecialEquipPrefs"');
+?>
+--EXPECT--
+Methods:
+  > test(SpecialEquipPrefs $testParam): void
+
+Types:
+  > http://test-uri/:StringLength1to128 extends string
+  > http://test-uri/:EmailType extends StringLength1to128 {
+    StringLength1to128 $_
+    @string $EmailType
+  }
+  > http://test-uri/:VerificationType {
+    ?EmailType $Email
+  }

--- a/tests/PhpCompatibility/schema1005.phpt
+++ b/tests/PhpCompatibility/schema1005.phpt
@@ -1,0 +1,42 @@
+--TEST--
+SOAP XML Schema 1005: Nested inline elements wrapped in choice element container
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+	<complexType name="LoyaltyTravelInfoType">
+        <choice>
+          <element name="HotelStayInfo">
+            <complexType>
+              <sequence>
+                <element name="ReservationID" type="string" />
+              </sequence>
+            </complexType>
+          </element>
+          <element name="AirFlightInfo">
+            <complexType>
+              <sequence>
+                <element name="FlightSegment" type="string"/>
+              </sequence>
+            </complexType>
+          </element>
+        </choice>
+      </complexType>
+EOF;
+test_schema($schema,'type="tns:LoyaltyTravelInfoType"');
+?>
+--EXPECT--
+Methods:
+  > test(LoyaltyTravelInfoType $testParam): void
+
+Types:
+  > http://test-uri/:LoyaltyTravelInfoType {
+    ?HotelStayInfo $HotelStayInfo
+    ?AirFlightInfo $AirFlightInfo
+  }
+  > http://test-uri/:HotelStayInfo {
+    ?string $ReservationID
+  }
+  > http://test-uri/:AirFlightInfo {
+    ?string $FlightSegment
+  }

--- a/tests/PhpCompatibility/schema1006.phpt
+++ b/tests/PhpCompatibility/schema1006.phpt
@@ -1,0 +1,16 @@
+--TEST--
+SOAP XML Schema 1006: simple element types
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+    <element name="AcknowledgeReceipt" type="anyType" />
+EOF;
+test_schema($schema,'type="tns:AcknowledgeReceipt"');
+?>
+--EXPECT--
+Methods:
+  > test(AcknowledgeReceipt $testParam): void
+
+Types:
+  > http://test-uri/:AcknowledgeReceipt

--- a/tests/PhpCompatibility/schema1007.phpt
+++ b/tests/PhpCompatibility/schema1007.phpt
@@ -1,0 +1,49 @@
+--TEST--
+SOAP XML Schema 1007: Deeply nested complex-type declarations inside complexTypes
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+    <complexType name="LocationType">
+		<simpleContent>
+			<extension base="string">
+			    <attribute name="LocationCode" type="string" use="optional" />
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="VerificationType">
+        <sequence>
+            <element name="Email" type="string" minOccurs="0" />
+            <element name="StartLocation" minOccurs="0">
+                <complexType>
+                    <simpleContent>
+                        <extension base="tns:LocationType">
+                            <attribute name="AssociatedDateTime" type="dateTime" use="optional" />
+                        </extension>
+                    </simpleContent>
+                </complexType>
+            </element>
+        </sequence>
+    </complexType>
+
+EOF;
+test_schema($schema,'type="tns:VerificationType"');
+?>
+--EXPECT--
+Methods:
+  > test(VerificationType $testParam): void
+
+Types:
+  > http://test-uri/:LocationType extends string {
+    string $_
+    @string $LocationCode
+  }
+  > http://test-uri/:VerificationType {
+    ?string $Email
+    ?StartLocation $StartLocation
+  }
+  > http://test-uri/:StartLocation extends LocationType {
+    string $_
+    @string $LocationCode
+    @dateTime $AssociatedDateTime
+  }

--- a/tests/PhpCompatibility/test_schema.inc
+++ b/tests/PhpCompatibility/test_schema.inc
@@ -61,8 +61,6 @@ function test_schema($schema, $type, $style="rpc",$use="encoded", $attributeForm
       echo implode(PHP_EOL, $metadata->getMethods()->map(fn(Method $method) => '  > ' . (new ShortMethodFormatter())($method)));
       echo PHP_EOL . PHP_EOL;
 
-      //var_dump($metadata->getTypes()->fetchFirstByName('SpecialEquipPrefs'));
-      //var_dump($metadata->getTypes()->fetchFirstByName('SpecialEquipPref'));
       echo "Types:" . PHP_EOL;
       echo implode(PHP_EOL, $metadata->getTypes()->map(fn(Type $type) => '  > ' . (new LongTypeFormatter())($type)));
       echo PHP_EOL . PHP_EOL;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

* Adds support for nested inline elements in other element containers like choices
* Improves base type inference for both simple types and attribute types (enums, unions, ...)
