### PR TITLE
feat: add support for symfony 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php-soap/wsdl": "^1.4",
         "veewee/xml": "^2.6",
         "azjezz/psl": "^2.4",
-        "symfony/console": "^6.2 || ^7.0"
+        "symfony/console": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "symfony/var-dumper": "^6.1",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | #17 

#### Summary
This PR add support for symfony 5.4 / 6.0 / 6.1 and sync the requirements with the [base cli application](https://github.com/php-soap/wsdl/blob/22a8fce96a8d151004fa4e639c6968ec0aa33878/composer.json#L35C1-L35C51)
