### PR TITLE
Allow empty enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "goetas-webservices/xsd-reader": "^0.4.1",
-        "php-soap/engine": "^2.6",
+        "php-soap/engine": "^2.7",
         "php-soap/wsdl": "^1.4",
         "veewee/xml": "^2.6 || ^3.0",
         "azjezz/psl": "^2.4",

--- a/tests/PhpCompatibility/schema1011.phpt
+++ b/tests/PhpCompatibility/schema1011.phpt
@@ -1,0 +1,21 @@
+--TEST--
+SOAP XML Schema 1001: Empty enumarable
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+    <simpleType name="EmptySimpleType">
+        <restriction base="string">
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+EOF;
+test_schema($schema,'type="tns:EmptySimpleType"');
+?>
+--EXPECT--
+Methods:
+  > test(EmptySimpleType $testParam): void
+
+Types:
+  > http://test-uri/:EmptySimpleType extends string in ()
+


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |

#### Summary

Fixes https://github.com/phpro/soap-client/pull/507

```xml
<xs:simpleType name="EmptySimpleType">
    <xs:restriction base="xs:string">
      <xs:enumeration value=""/>
    </xs:restriction>
  </xs:simpleType>
```
