### PR TITLE
Allow empty return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "goetas-webservices/xsd-reader": "^0.4.1",
         "php-soap/engine": "^2.8",
         "php-soap/wsdl": "^1.4",
+        "php-soap/xml": "^1.6.0",
         "veewee/xml": "^2.6 || ^3.0",
         "azjezz/psl": "^2.4",
         "symfony/console": "^5.4 || ^6.0 || ^7.0"

--- a/src/Metadata/Converter/Wsdl1ToMethodsConverter.php
+++ b/src/Metadata/Converter/Wsdl1ToMethodsConverter.php
@@ -7,7 +7,6 @@ use Soap\Engine\Metadata\Collection\MethodCollection;
 use Soap\Engine\Metadata\Collection\ParameterCollection;
 use Soap\Engine\Metadata\Model\Method;
 use Soap\Engine\Metadata\Model\Parameter;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 use Soap\WsdlReader\Locator\Wsdl1SelectedServiceLocator;
 use Soap\WsdlReader\Metadata\Converter\Methods\Configurator\BindingOperationConfigurator;
@@ -51,13 +50,7 @@ final class Wsdl1ToMethodsConverter
         $parameters = $inputMessage->map($convertMessageToTypesDict)->mapOr(
             static fn (array $types) => map_with_key(
                 $types,
-                static fn (string $name, XsdType $type) => new Parameter(
-                    $name,
-                    // Make sure the target type encodes into an **element** that is **named like the parameter part**.
-                    $type
-                        ->withXmlTargetNodeName($name)
-                        ->withMeta(static fn (TypeMeta $meta): TypeMeta => $meta->withIsElement(true))
-                )
+                static fn (string $name, XsdType $type) => new Parameter($name, $type)
             ),
             []
         );

--- a/src/Model/Definitions/Part.php
+++ b/src/Model/Definitions/Part.php
@@ -7,7 +7,7 @@ final class Part
 {
     public function __construct(
         public readonly string $name,
-        public readonly QNamed $element,
+        public readonly ?QNamed $element,
     ) {
     }
 }

--- a/src/Parser/Definitions/MessageParser.php
+++ b/src/Parser/Definitions/MessageParser.php
@@ -24,10 +24,18 @@ final class MessageParser
                 ...$xpath->query('./wsdl:part', $message)
                     ->expectAllOfType(DOMElement::class)
                     ->map(
-                        static fn (DOMElement $part) => new Part(
-                            name: $part->getAttribute('name'),
-                            element: QNamed::parse($part->getAttribute('element') ?: $part->getAttribute('type'))
-                        )
+                        static function (DOMElement $part) {
+                            $element = match (true) {
+                                $part->hasAttribute('element') => QNamed::parse($part->getAttribute('element')),
+                                $part->hasAttribute('type') => QNamed::parse($part->getAttribute('type')),
+                                default => null
+                            };
+
+                            return new Part(
+                                name: $part->getAttribute('name'),
+                                element: $element,
+                            );
+                        }
                     )
             )
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes/no
| Fixed issues |

#### Summary

This change:

* allows for empty message part types
* enhances method return type information as well as parameters


