### PR TITLE
Improve XML typename logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
-        "goetas-webservices/xsd-reader": "^0.4.5",
+        "goetas-webservices/xsd-reader": "^0.4.6",
         "php-soap/engine": "^2.9",
         "php-soap/wsdl": "^1.4",
         "php-soap/xml": "^1.6.0",

--- a/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
@@ -27,7 +27,7 @@ final class XmlTypeInfoConfigurator
 
         return $engineType
             ->withXmlTargetNodeName($itemName ?: $typeName)
-            ->withXmlTypeName($typeName)
+            ->withXmlTypeName($typeName ?: $itemName ?: '')
             ->withXmlNamespace($typeNamespace)
             ->withXmlNamespaceName(
                 $context->knownNamespaces->lookupNameFromNamespace($typeNamespace)->unwrapOr(


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

Target `XmlTypeName` was empty on typed elements.
This PR falls back to the element name if the type name is empty.
