### PR TITLE
Mark types as locally configured types

### DIFF
--- a/src/Metadata/Converter/Types/Configurator/AttributeBaseTypeConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/AttributeBaseTypeConfigurator.php
@@ -23,6 +23,14 @@ final class AttributeBaseTypeConfigurator
             default => null,
         };
 
+        // Attributes can have inline types. Mark the attribute as a local type in that case.
+        $isConsideredAnInlineType = $baseType && $baseType->getName() === null;
+        if ($isConsideredAnInlineType) {
+            $engineType = $engineType->withMeta(
+                static fn ($meta) => $meta->withIsLocal(true)
+            );
+        }
+
         return (new SimpleTypeConfigurator())($engineType, $baseType, $context);
     }
 }

--- a/src/Metadata/Converter/Types/Configurator/ElementSingleConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/ElementSingleConfigurator.php
@@ -16,11 +16,19 @@ final class ElementSingleConfigurator
             return $engineType;
         }
 
+        // Elements can have inline types. Mark the attribute as a local type in that case.
+        $innerType = $xsdType->getType();
+        $isConsideredAnInlineType = $innerType && $innerType->getName() === null;
+        if ($isConsideredAnInlineType) {
+            $engineType = $engineType->withMeta(
+                static fn ($meta) => $meta->withIsLocal(true)
+            );
+        }
+
         return $engineType
             ->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta
                     ->withIsQualified($xsdType->isQualified())
-                    ->withIsLocal($xsdType->isLocal())
                     ->withIsNil($xsdType->isNil())
                     ->withIsNullable($meta->isNullable()->unwrapOr(false) || $xsdType->isNil())
             );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |

#### Summary

Marks types as `local` if they are inline types.

Examples:

```xml
<element name="GetCustomerDetailsRequest">
    <complexType>
        <sequence>
            <element name="customerId" type="xsd:string" />
        </sequence>
    </complexType>
</element>
```
GetCustomerDetailsRequest -> will be marked as `local` because it uses an internal complexType.


```xml
<complexType name="VehicleCoreType">
    <attribute name="DriveType" use="optional">
        <simpleType>
            <restriction base="NMTOKEN">
                <enumeration value="AWD" />
                <enumeration value="4WD" />
                <enumeration value="Unspecified" />
            </restriction>
        </simpleType>
    </attribute>
</complexType>
```

The type of property `DriveType` -> will be marked as `local` because it uses an internal simpleType.
