### PR TITLE
Increase occurence configurator priority

### DIFF
--- a/src/Metadata/Converter/Types/Configurator/ElementConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/ElementConfigurator.php
@@ -23,12 +23,12 @@ final class ElementConfigurator
             static fn (EngineType $engineType): EngineType => $engineType->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsElement(true)
             ),
+            static fn (EngineType $engineType): EngineType => (new OccurrencesConfigurator())($engineType, $element, $context),
             static fn (EngineType $engineType): EngineType => (new TypeConfigurator())($engineType, $xsdType, $context),
             static fn (EngineType $engineType): EngineType => (new XmlTypeInfoConfigurator())($engineType, $element, $context),
             static fn (EngineType $engineType): EngineType => (new DocsConfigurator())($engineType, $element, $context),
             static fn (EngineType $engineType): EngineType => (new DefaultConfigurator())($engineType, $element, $context),
             static fn (EngineType $engineType): EngineType => (new FixedConfigurator())($engineType, $element, $context),
-            static fn (EngineType $engineType): EngineType => (new OccurrencesConfigurator())($engineType, $element, $context),
             static fn (EngineType $engineType): EngineType => (new ElementSingleConfigurator())($engineType, $element, $context),
         )($engineType);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

For soap arrays, the max occurences get overridden by the declaring element.
This PR fixes that by increasing the element's occurence configurator priority above the type configurator.
That way, the max occurences that get calculated by the soap encoding configurators will not get overridden by the element min / max occurs.

For reference:
https://github.com/mcwnuq/test-soap-client/issues/1


