### PR TITLE
Always use element namespace as target namespace

### DIFF
--- a/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
@@ -24,16 +24,19 @@ final class XmlTypeInfoConfigurator
         $item = $xsdType instanceof Item ? $xsdType : null;
         $type = $xsdType instanceof Type ? $xsdType : $item?->getType();
 
+        $parentContext = $context->parent()->unwrapOr(null);
+        $itemIsSchemaRootElement = $item instanceof ElementItem && $parentContext?->currentParent() === $xsdType;
+
         $itemName = $item?->getName() ?: $type?->getName();
         $typeName = $type?->getName() ?? '';
         $targetNamespace = $xsdType->getSchema()->getTargetNamespace() ?? '';
         $typeNamespace = match (true) {
-            $item instanceof ElementItem => $targetNamespace,
+            $itemIsSchemaRootElement => $targetNamespace,
             default => $type?->getSchema()->getTargetNamespace() ?: $targetNamespace,
         };
 
-        $parentContext = $context->parent()->unwrapOr(null);
         $xmlTypeName = match(true) {
+            $itemIsSchemaRootElement && $item => $item->getName(),
             $parentContext && $item instanceof ElementItem => (new ElementTypeNameDetector())($item, $parentContext),
             $parentContext && $item instanceof AttributeItem => (new AttributeTypeNameDetector())($item, $parentContext),
             default => $typeName,

--- a/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
+++ b/src/Metadata/Converter/Types/Configurator/XmlTypeInfoConfigurator.php
@@ -27,7 +27,10 @@ final class XmlTypeInfoConfigurator
         $itemName = $item?->getName() ?: $type?->getName();
         $typeName = $type?->getName() ?? '';
         $targetNamespace = $xsdType->getSchema()->getTargetNamespace() ?? '';
-        $typeNamespace = $type?->getSchema()->getTargetNamespace() ?: $targetNamespace;
+        $typeNamespace = match (true) {
+            $item instanceof ElementItem => $targetNamespace,
+            default => $type?->getSchema()->getTargetNamespace() ?: $targetNamespace,
+        };
 
         $parentContext = $context->parent()->unwrapOr(null);
         $xmlTypeName = match(true) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/phpro/soap-client/issues/585

#### Summary

Fixes https://github.com/phpro/soap-client/issues/585

```xml
<xs:schema xmlns="http://www.capita-software-services.com/scp/simple"
           xmlns:scpbase="http://www.capita-software-services.com/scp/base"
           xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
           elementFormDefault="qualified" targetNamespace="http://www.capita-software-services.com/scp/simple">
    <xs:import namespace="http://www.capita-software-services.com/scp/base"/>
    <xs:element name="scpSimpleQueryRequest" type="scpbase:scpQueryRequest"/>
<xs:schema>
```

Previously, this resulted in the element scpSimpleQueryRequest being targeted to the `scpbase` namespace.
This is not correct, given that the element is axtyally in the `simple` namespace, which results in the type collection not being able to find this element. (only the complexType in scpbase).

This fixes that issue and makes sure the element is also encoded as scpSimple in the encoder.
