### PR TITLE
Enhance property meta with container meta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-dom": "*",
-        "goetas-webservices/xsd-reader": "^0.4.8",
+        "goetas-webservices/xsd-reader": "^0.4.11",
         "php-soap/engine": "^2.13",
         "php-soap/wsdl": "^1.10",
         "php-soap/xml": "^1.8.0",

--- a/tests/PhpCompatibility/schema1015.phpt
+++ b/tests/PhpCompatibility/schema1015.phpt
@@ -1,0 +1,66 @@
+--TEST--
+SOAP XML Schema 1015: Group ref with minOccurs / MaxOccurs
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+    <complexType name="nullableGroupRef">
+        <sequence>
+            <group minOccurs="0" ref="tns:mygroup"/>
+        </sequence>
+    </complexType>
+    <complexType name="listGroupRef">
+        <sequence>
+            <group minOccurs="0" maxOccurs="unbounded" ref="tns:mygroup"/>
+        </sequence>
+    </complexType>
+    <complexType name="scopedGroupRef">
+        <sequence>
+            <group minOccurs="2" maxOccurs="6" ref="tns:mygroup"/>
+        </sequence>
+    </complexType>
+    <complexType name="singleGroupRef">
+        <sequence>
+            <group minOccurs="1" maxOccurs="1" ref="tns:mygroup"/>
+        </sequence>
+    </complexType>
+    <group name="mygroup">
+        <sequence>
+            <element name="nullable" type="string" minOccurs="0" />
+            <element name="list" type="string" minOccurs="0" maxOccurs="unbounded" />
+            <element name="scoped" type="string" minOccurs="3" maxOccurs="5" />
+            <element name="single" type="string" minOccurs="1" maxOccurs="1"/>
+        </sequence>
+    </group>
+EOF;
+test_schema($schema,'type="tns:Element"');
+?>
+--EXPECT--
+Methods:
+  > test(Element $testParam): void
+
+Types:
+  > http://test-uri/:nullableGroupRef {
+    ?string $nullable
+    array<int<0, max>, string> $list
+    array<int<0, 5>, string> $scoped
+    ?string $single
+  }
+  > http://test-uri/:listGroupRef {
+    array<int<0, max>, string> $nullable
+    array<int<0, max>, string> $list
+    array<int<0, max>, string> $scoped
+    array<int<0, max>, string> $single
+  }
+  > http://test-uri/:scopedGroupRef {
+    array<int<0, 6>, string> $nullable
+    array<int<0, max>, string> $list
+    array<int<6, 30>, string> $scoped
+    array<int<2, 6>, string> $single
+  }
+  > http://test-uri/:singleGroupRef {
+    ?string $nullable
+    array<int<0, max>, string> $list
+    array<int<3, 5>, string> $scoped
+    string $single
+  }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/phpro/soap-client/issues/586

#### Summary

Fixes https://github.com/phpro/soap-client/issues/586

❗  Awaiting https://github.com/goetas-webservices/xsd-reader/pull/91 to be merged. This will make the unit test pass.

Currently, the metadata parser does not take into account the minOccurs on group-ref level:

```xml
            <xs:complexType name="storeCardResult">
                <xs:sequence>
                    <xs:group minOccurs="0" ref="securityDetailsGroup"/>
                </xs:sequence>
            </xs:complexType>
            <xs:group name="securityDetailsGroup">
                <xs:sequence>
                    <xs:element name="securityDetails" type="securityDetails"/>
                </xs:sequence>
            </xs:group>
            <xs:complexType name="securityDetails">
                <xs:sequence>
                    <xs:element minOccurs="0" name="threeDSecure" type="threeDSecure"/>
                    <xs:element minOccurs="0" name="resultAVVCVV" type="xs:string"/>
                </xs:sequence>
            </xs:complexType>
```


**TODO**

- [ ] Validate if override logic make sense. Take into account the logic in https://github.com/goetas-webservices/xsd-reader/pull/88