### PR TITLE
Test: repeating group ref around a choice yields unbounded list members

### DIFF
--- a/tests/PhpCompatibility/schema1017.phpt
+++ b/tests/PhpCompatibility/schema1017.phpt
@@ -1,0 +1,31 @@
+--TEST--
+SOAP XML Schema 1017: Repeating group ref around a choice exposes members as optional unbounded lists
+--FILE--
+<?php
+include __DIR__."/test_schema.inc";
+$schema = <<<EOF
+    <group name="Operation">
+        <choice>
+            <element name="delete" type="string" />
+            <element name="write" type="string" />
+        </choice>
+    </group>
+    <complexType name="Message">
+        <sequence>
+            <element minOccurs="0" name="transactionId" type="string" />
+            <group minOccurs="0" maxOccurs="unbounded" ref="tns:Operation" />
+        </sequence>
+    </complexType>
+EOF;
+test_schema($schema,'type="tns:Message"');
+?>
+--EXPECT--
+Methods:
+  > test(Message $testParam): void
+
+Types:
+  > http://test-uri/:Message {
+    ?string $transactionId
+    array<int<0, max>, string> $delete
+    array<int<0, max>, string> $write
+  }


### PR DESCRIPTION
Adds an end-to-end regression test for a `<group>` referenced with `maxOccurs="unbounded"` around an `<xs:choice>` (the `transfer.operation` shape from real XZuFi/KRZN WSDLs). Both choice members must be read as optional, unbounded list elements on the referencing type:

```
> http://test-uri/:Message {
    ?string $transactionId
    array<int<0, max>, string> $delete
    array<int<0, max>, string> $write
  }
```

### Blocked on

The fix lives in xsd-reader: goetas-webservices/xsd-reader#93 (`Choice::getElements()` propagates a repeating choice's occurrences onto its members). Until that is merged, released, and the `goetas-webservices/xsd-reader` constraint here is bumped, this test fails against the published dependency. Opened as a draft for that reason.
